### PR TITLE
refactor: overhaul SSL module

### DIFF
--- a/k8_certs.tf
+++ b/k8_certs.tf
@@ -2,16 +2,13 @@
   DO NOT MODIFY ANYTHING IN LOCALS!!!
 */
 locals {
-  # Name of the control plane
-  control_plane_vm_name = var.control_plane_settings.vm_name
 
-  # Internal IP Address of Control Plane (e.g., 10.96.0.1)
-  internal_control_plane_ip = "10.96.0.1"
-  # External IP Address of Control Plane (e.g., 192.168.2.127)
-  external_control_plane_ip = "192.168.2.127"
+  # Determine whether to initialize the certs module or not
+  create_certificates = var.create_certificates || var.create_etcd_certificates ? 1 : 0
 }
 
 module "certs" {
+  count  = local.create_certificates
   source = "./modules/kubernetes_certificates"
 
   create_certificates      = var.create_certificates
@@ -21,7 +18,19 @@ module "certs" {
   cluster_domain    = var.cluster_domain
   cluster_namespace = var.cluster_namespace
 
-  control_plane_name        = local.control_plane_vm_name
-  internal_control_plane_ip = local.internal_control_plane_ip
-  external_control_plane_ip = local.external_control_plane_ip
+  control_plane_names = module.control_planes[*].name
+
+  /*
+    Internal Control Plane IP Addresses
+      This variable will iterate through the number of Control Plane Virtual Machines
+        and create an IP Address based off of the Service Network Subnet (e.g., 10.96.0.0/12).
+
+      For example, if the user is creating 3 control planes and using the default Service Network,
+        the following IP Addresses will be created:
+          * 10.96.0.1
+          * 10.96.0.2
+          * 10.96.0.3
+  */
+  internal_control_plane_ips = try([for i, vm in module.control_planes : cidrhost(var.service_network, (i + 1))], cidrhost(var.service_network, 1))
+  external_control_plane_ips = module.control_planes[*].ip
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 /*
-  This file computers all of the necessary local variables for k8_infra.tf.
+  This file computers all of the necessary local variables for k8_infrastructure.tf.
 */
 locals {
   /*

--- a/modules/kubernetes_certificates/README.md
+++ b/modules/kubernetes_certificates/README.md
@@ -76,9 +76,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_control_plane_name"></a> [control\_plane\_name](#input\_control\_plane\_name) | (String) The name of the Control Plane. This can be the machine's name. | `string` | n/a | yes |
-| <a name="input_external_control_plane_ip"></a> [external\_control\_plane\_ip](#input\_external\_control\_plane\_ip) | (String) The External IP Address of the Control Plane. | `string` | n/a | yes |
-| <a name="input_internal_control_plane_ip"></a> [internal\_control\_plane\_ip](#input\_internal\_control\_plane\_ip) | (String) The Internal IP Address of the Control Plane. | `string` | n/a | yes |
+| <a name="input_control_plane_names"></a> [control\_plane\_names](#input\_control\_plane\_names) | [List(String)] The name of the Control Plane(s). This can be the Virtual Machine's name. | `list(string)` | n/a | yes |
+| <a name="input_external_control_plane_ips"></a> [external\_control\_plane\_ips](#input\_external\_control\_plane\_ips) | [List(String)] The External IP Address(es) of the Control Plane(s). | `list(string)` | n/a | yes |
+| <a name="input_internal_control_plane_ips"></a> [internal\_control\_plane\_ips](#input\_internal\_control\_plane\_ips) | [List(String)] The Internal IP Address(es) of the Control Plane(s). | `list(string)` | n/a | yes |
 | <a name="input_apiserver_client_name"></a> [apiserver\_client\_name](#input\_apiserver\_client\_name) | (String) The name of the Kubernetes API Server Client Certificate. Default is 'kube-apiserver-kubelet-client'. | `string` | `"kube-apiserver-kubelet-client"` | no |
 | <a name="input_apiserver_name"></a> [apiserver\_name](#input\_apiserver\_name) | (String) The name of the Kubernetes API Server. Default is 'kube-apiserver'. | `string` | `"kube-apiserver"` | no |
 | <a name="input_certificate_directory"></a> [certificate\_directory](#input\_certificate\_directory) | The default directory of the kubernetes certificates. Default is '/etc/kubernetes/pki' | `string` | `"/etc/kubernetes/pki"` | no |

--- a/modules/kubernetes_certificates/api_server.tf
+++ b/modules/kubernetes_certificates/api_server.tf
@@ -19,20 +19,11 @@ resource "tls_cert_request" "apiserver_ca_csr" {
   }
 
   dns_names = [
-    local.control_plane_name,
-    local.cluster_name,
-    local.cluster_name_and_namespace,
-    local.cluster_namespace_fqdn,
-    local.cluster_namespace_fqdn_and_domain
+    for name in concat(local.control_plane_names, tolist([local.cluster_name, local.cluster_name_and_namespace, local.cluster_namespace_fqdn, local.cluster_namespace_fqdn_and_domain])) : tostring(name)
   ]
 
   ip_addresses = [
-    local.internal_control_plane_ip,
-    local.external_control_plane_ip
-  ]
-
-  depends_on = [
-    data.tls_public_key.apiserver_key
+    for ip in concat(local.internal_control_plane_ips, local.external_control_plane_ips) : tostring(ip)
   ]
 }
 
@@ -54,11 +45,6 @@ resource "tls_locally_signed_cert" "apiserver_crt" {
     "digital_signature",
     "key_encipherment",
     "server_auth"
-  ]
-
-  depends_on = [
-    data.tls_certificate.ca_crt,
-    data.tls_public_key.ca_key
   ]
 }
 
@@ -82,10 +68,6 @@ resource "tls_cert_request" "apiserver_client_csr" {
     common_name  = local.apiserver_kubelet_client_cn
     organization = "system:masters"
   }
-
-  depends_on = [
-    data.tls_public_key.apiserver_kubelet_client_key
-  ]
 }
 
 
@@ -107,11 +89,6 @@ resource "tls_locally_signed_cert" "apiserver_kubelet_client_crt" {
     "digital_signature",
     "key_encipherment",
     "client_auth"
-  ]
-
-  depends_on = [
-    data.tls_certificate.ca_crt,
-    data.tls_public_key.ca_key
   ]
 }
 
@@ -135,10 +112,6 @@ resource "tls_cert_request" "apiserver_etcd_client_csr" {
     common_name  = local.apiserver_etcd_client
     organization = "system:masters"
   }
-
-  depends_on = [
-    data.tls_public_key.apiserver_etcd_client_key
-  ]
 }
 
 /*
@@ -159,11 +132,6 @@ resource "tls_locally_signed_cert" "apiserver_etcd_client_crt" {
     "digital_signature",
     "key_encipherment",
     "client_auth"
-  ]
-
-  depends_on = [
-    data.tls_certificate.etcd_ca_crt,
-    data.tls_public_key.etcd_ca_key
   ]
 }
 

--- a/modules/kubernetes_certificates/ca.tf
+++ b/modules/kubernetes_certificates/ca.tf
@@ -32,10 +32,6 @@ resource "tls_self_signed_cert" "ca_crt" {
   subject {
     common_name = local.cluster_name
   }
-
-  depends_on = [
-    data.tls_public_key.ca_key
-  ]
 }
 
 /*

--- a/modules/kubernetes_certificates/etcd.tf
+++ b/modules/kubernetes_certificates/etcd.tf
@@ -32,10 +32,6 @@ resource "tls_self_signed_cert" "etcd_ca_crt" {
   subject {
     common_name = local.etcd_ca_name
   }
-
-  depends_on = [
-    data.tls_public_key.etcd_ca_key
-  ]
 }
 
 /*
@@ -58,10 +54,6 @@ resource "tls_cert_request" "etcd_healthcheck_client_csr" {
     common_name  = local.etcd_healthcheck_name
     organization = "system:masters"
   }
-
-  depends_on = [
-    data.tls_public_key.etcd_healthcheck_client_key
-  ]
 }
 
 /*
@@ -83,11 +75,6 @@ resource "tls_locally_signed_cert" "etcd_healthcheck_client_crt" {
     "key_encipherment",
     "client_auth"
   ]
-
-  depends_on = [
-    data.tls_certificate.etcd_ca_crt,
-    data.tls_public_key.etcd_ca_key
-  ]
 }
 
 /*
@@ -107,23 +94,16 @@ resource "tls_cert_request" "etcd_peer_csr" {
   private_key_pem = data.tls_public_key.etcd_peer_key[count.index].private_key_pem
 
   dns_names = [
-    "localhost",
-    local.control_plane_name,
+    for name in concat(local.control_plane_names, tolist(["localhost"])) : tostring(name)
   ]
 
   ip_addresses = [
-    local.external_control_plane_ip,
-    "127.0.0.1",
-    "0000:0000:0000:0000:0000:0000:0000:0001"
+    for ip in concat(local.external_control_plane_ips, tolist(["127.0.0.1", "0000:0000:0000:0000:0000:0000:0000:0001"])) : tostring(ip)
   ]
 
   subject {
-    common_name = local.control_plane_name
+    common_name = local.control_plane_names[0]
   }
-
-  depends_on = [
-    data.tls_public_key.etcd_peer_key
-  ]
 }
 
 /*
@@ -144,11 +124,6 @@ resource "tls_locally_signed_cert" "etcd_peer_crt" {
     "server_auth",
     "client_auth"
   ]
-
-  depends_on = [
-    data.tls_certificate.etcd_ca_crt,
-    data.tls_public_key.etcd_ca_key
-  ]
 }
 
 /*
@@ -168,23 +143,16 @@ resource "tls_cert_request" "etcd_server_csr" {
   private_key_pem = data.tls_public_key.etcd_server_key[count.index].private_key_pem
 
   dns_names = [
-    "localhost",
-    local.control_plane_name,
+    for name in concat(local.control_plane_names, tolist(["localhost"])) : tostring(name)
   ]
 
   ip_addresses = [
-    local.external_control_plane_ip,
-    "127.0.0.1",
-    "0000:0000:0000:0000:0000:0000:0000:0001"
+    for ip in concat(local.external_control_plane_ips, tolist(["127.0.0.1", "0000:0000:0000:0000:0000:0000:0000:0001"])) : tostring(ip)
   ]
 
   subject {
-    common_name = local.control_plane_name
+    common_name = local.control_plane_names[0]
   }
-
-  depends_on = [
-    data.tls_public_key.etcd_server_key
-  ]
 }
 
 /*
@@ -204,11 +172,6 @@ resource "tls_locally_signed_cert" "etcd_server_crt" {
   allowed_uses = [
     "server_auth",
     "client_auth"
-  ]
-
-  depends_on = [
-    data.tls_certificate.etcd_ca_crt,
-    data.tls_public_key.etcd_ca_key
   ]
 }
 

--- a/modules/kubernetes_certificates/front_proxy.tf
+++ b/modules/kubernetes_certificates/front_proxy.tf
@@ -32,10 +32,6 @@ resource "tls_self_signed_cert" "front_proxy_crt" {
   subject {
     common_name = local.front_proxy_ca_name
   }
-
-  depends_on = [
-    data.tls_public_key.front_proxy_key
-  ]
 }
 
 /*
@@ -57,10 +53,6 @@ resource "tls_cert_request" "front_proxy_client_csr" {
   subject {
     common_name = local.front_proxy_client_name
   }
-
-  depends_on = [
-    data.tls_public_key.front_proxy_client_key
-  ]
 }
 
 /*
@@ -81,11 +73,6 @@ resource "tls_locally_signed_cert" "front_proxy_client_crt" {
     "digital_signature",
     "key_encipherment",
     "client_auth"
-  ]
-
-  depends_on = [
-    data.tls_certificate.front_proxy_crt,
-    data.tls_public_key.front_proxy_key
   ]
 }
 

--- a/modules/kubernetes_certificates/locals.tf
+++ b/modules/kubernetes_certificates/locals.tf
@@ -6,13 +6,12 @@ locals {
   etcd_cert_directory = trimsuffix(var.etcd_certificate_directory, "/")
 
   # Name of the control plane
-  control_plane_name = var.control_plane_name
-
+  control_plane_names = var.control_plane_names
 
   # Internal IP Address of Control Plane (e.g., 10.96.0.1)
-  internal_control_plane_ip = var.internal_control_plane_ip
+  internal_control_plane_ips = var.internal_control_plane_ips
   # External IP Address of Control Plane (e.g., 192.168.2.126)
-  external_control_plane_ip = var.external_control_plane_ip
+  external_control_plane_ips = var.external_control_plane_ips
 
   # Default Value: kubernetes
   cluster_name = var.cluster_name
@@ -29,6 +28,7 @@ locals {
   cluster_namespace_fqdn = "${local.cluster_name_and_namespace}.svc"
   # Default Value: kubernetes.default.svc.cluster.local
   cluster_namespace_fqdn_and_domain = "${local.cluster_namespace_fqdn}.${local.cluster_domain}"
+
 
   # Default Value: kube-apiserver
   apiserver_name = var.apiserver_name

--- a/modules/kubernetes_certificates/variables.tf
+++ b/modules/kubernetes_certificates/variables.tf
@@ -28,9 +28,9 @@ variable "etcd_certificate_directory" {
 }
 
 
-variable "control_plane_name" {
-  description = "(String) The name of the Control Plane. This can be the machine's name."
-  type        = string
+variable "control_plane_names" {
+  description = "[List(String)] The name of the Control Plane(s). This can be the Virtual Machine's name."
+  type        = list(string)
 }
 
 variable "cluster_name" {
@@ -137,22 +137,22 @@ variable "validity_period_hours" {
   default = 87600
 }
 
-variable "internal_control_plane_ip" {
-  description = "(String) The Internal IP Address of the Control Plane."
-  type        = string
+variable "internal_control_plane_ips" {
+  description = "[List(String)] The Internal IP Address(es) of the Control Plane(s)."
+  type        = list(string)
 
   validation {
-    condition     = can(regex("^(?:(?:2(?:[0-4][0-9]|5[0-5])|[0-1]?[0-9]?[0-9])\\.){3}(?:(?:2([0-4][0-9]|5[0-5])|[0-1]?[0-9]?[0-9]))$", var.internal_control_plane_ip))
+    condition     = alltrue([for ip in var.internal_control_plane_ips : can(regex("^(?:(?:2(?:[0-4][0-9]|5[0-5])|[0-1]?[0-9]?[0-9])\\.){3}(?:(?:2([0-4][0-9]|5[0-5])|[0-1]?[0-9]?[0-9]))$", ip))])
     error_message = "Invalid IP Address. Please provide an IP Address that meets IPv4 CIDR-Notation (e.g., 192.168.1.1)."
   }
 }
 
-variable "external_control_plane_ip" {
-  description = "(String) The External IP Address of the Control Plane."
-  type        = string
+variable "external_control_plane_ips" {
+  description = "[List(String)] The External IP Address(es) of the Control Plane(s)."
+  type        = list(string)
 
   validation {
-    condition     = can(regex("^(?:(?:2(?:[0-4][0-9]|5[0-5])|[0-1]?[0-9]?[0-9])\\.){3}(?:(?:2([0-4][0-9]|5[0-5])|[0-1]?[0-9]?[0-9]))$", var.external_control_plane_ip))
+    condition     = alltrue([for ip in var.external_control_plane_ips : can(regex("^(?:(?:2(?:[0-4][0-9]|5[0-5])|[0-1]?[0-9]?[0-9])\\.){3}(?:(?:2([0-4][0-9]|5[0-5])|[0-1]?[0-9]?[0-9]))$", ip))])
     error_message = "Invalid IP Address. Please provide an IP Address that meets IPv4 CIDR-Notation (e.g., 192.168.1.1)."
   }
 }

--- a/setup_control_plane.tf
+++ b/setup_control_plane.tf
@@ -1,6 +1,6 @@
 locals {
-  import_certs      = (var.create_certificates || var.create_etcd_certificates) && local.control_plane_count > 0 ? local.control_plane_count : 0
-  cert_destinations = local.import_certs > 0 ? join(" ", module.certs.all_certificates_destinations) : ""
+
+  import_certs = (var.create_certificates || var.create_etcd_certificates) && local.control_plane_count > 0 ? local.control_plane_count : 0
 
   prepare_node_script_template = "${path.module}/templates/prepare_control_node.sh.tftpl"
   prepare_node_script_rendered = "${path.module}/rendered/prepare_control_node.sh"
@@ -15,7 +15,7 @@ resource "local_file" "prepare_control_node_script" {
   count = local.control_plane_count > 0 ? 1 : 0
 
   content = templatefile(local.prepare_node_script_template, {
-    cert_destinations    = local.cert_destinations
+    cert_destinations    = local.import_certs > 0 ? join(" ", module.certs[count.index].all_certificates_destinations) : ""
     cluster_domain       = var.cluster_domain
     cluster_name         = var.cluster_name
     cluster_namespace    = var.cluster_namespace


### PR DESCRIPTION
## Description
Originally, the SSL Module was created with a `TODO` on adding support for more than one Control Plane.

I'm at the point where I need to add more than one Control Plane for Haproxy / Keepalived testing. 

This PR adds support for more than one Control Plane in the SSL Creation process. 